### PR TITLE
add brazilian portuguese translation

### DIFF
--- a/i18n/pt-BR/cosmic_ext_applet_weather.ftl
+++ b/i18n/pt-BR/cosmic_ext_applet_weather.ftl
@@ -1,0 +1,4 @@
+latitude = Latitude
+longitude = Longitude
+temperature = Unidade de temperatura
+ip-location-toggle = Detectar localização automaticamente


### PR DESCRIPTION
The Brazilian Portuguese translation was removed after cosmic-utils/cosmic-ext-applet-weather#17. 

This PR adds it back.